### PR TITLE
Fix plot without points or only negatives

### DIFF
--- a/subprojects/libcairoplot/plotter.cpp
+++ b/subprojects/libcairoplot/plotter.cpp
@@ -242,6 +242,11 @@ void CGraph::CairoGraph::draw_series(const Cairo::RefPtr<Cairo::Context> &cr)
 
     for (size_t j = 0; j < numpoints.size(); ++j)
     {
+        if (!numpoints[j])
+        {
+            continue;
+        }
+
         cr->begin_new_path();
 
         double x = x_to_graph_coords(m_px[j][0]) / plot.zoom_factor_x;

--- a/subprojects/libcairoplot/plotterseries.cpp
+++ b/subprojects/libcairoplot/plotterseries.cpp
@@ -1,5 +1,8 @@
 #include "plotter.hpp"
+
+#include <cmath>
 #include <iostream>
+#include <limits>
 
 using namespace CarioGraphConstants;
 
@@ -176,8 +179,9 @@ void CGraph::CairoGraph::add_point(size_t seriesnum, const double x, const doubl
 
 void CGraph::CairoGraph::clear_series()
 {
-    xmax = ymax = std::numeric_limits<double>::min();
-    xmin = ymin = std::numeric_limits<double>::max();
+    // add and subtract epsilon to avoid out of range exception from std::stod
+    xmax = ymax = std::numeric_limits<double>::lowest() + std::numeric_limits<double>::epsilon();
+    xmin = ymin = std::numeric_limits<double>::max() - std::numeric_limits<double>::epsilon();
     text_object_font_family = "";
     seriescolour.clear();
     serieslinestyle.clear();


### PR DESCRIPTION
- Fix out_of_range exception from stod by adding/subtracting epsilon
- Fix nullptr access on empty plot
- Fix max being set to `min` (minimum positive value) instead of `lowest` (lowest negative value)